### PR TITLE
Make README consistent with assignment description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ python3 gen_form.py
 ```
 * Positive integers are used to denote a unique proposition
 * '-' is used to denote logical negation
-* '.' is used to denote logical inclusive or
-* '+' is used to denote logical and
+* '+' is used to denote logical inclusive or
+* '.' is used to denote logical and
 
 For example the output: '((-3) + (1 . (-5)))' denotes:
 
-((NEG X3) AND (X1 OR (NEG X5)))
+((NEG X3) OR (X1 AND (NEG X5)))
 
 The generator will always output a valid NNF formula that is fully parentisized. 


### PR DESCRIPTION
The description of the symbols `+` and `.` in the README are inconsistent with the description given in the extra credit assignment, which states:
![image](https://user-images.githubusercontent.com/32586859/60479810-1893bf80-9c55-11e9-8880-143c8b71e1dd.png)